### PR TITLE
Fix for Error 500 after successful PayPal-Payment

### DIFF
--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -231,7 +231,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
                 $this->View()->PaypalConfig = $this->plugin->Config();
                 $this->View()->PaypalResponse = $response;
             } else {
-                $this->forward('finish', 'checkout', array(
+                $this->forward('finish', 'checkout', 'frontend', array(
                     'sUniqueID' => $response['PAYMENTREQUEST_0_CUSTOM']
                 ));
             }

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -80,6 +80,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
             $this->forward('gateway');
         } else {
             $this->redirect(array('controller' => 'checkout'));
+            $this->forward('index', 'checkout');
         }
     }
 
@@ -189,7 +190,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
     public function recurringAction()
     {
         if (!$this->getAmount() || $this->getOrderNumber()) {
-            $this->redirect(array('controller' => 'checkout'));
+            $this->forward('index', 'checkout');
 
             return;
         }
@@ -231,13 +232,9 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
                 $this->View()->PaypalConfig = $this->plugin->Config();
                 $this->View()->PaypalResponse = $response;
             } else {
-                $this->redirect(
-                    array(
-                        'controller' => 'checkout',
-                        'action' => 'finish',
-                        'sUniqueID' => $response['PAYMENTREQUEST_0_CUSTOM']
-                    )
-                );
+                $this->forward('finish', 'checkout', array(
+                    'sUniqueID' => $response['PAYMENTREQUEST_0_CUSTOM']
+                ));
             }
         }
     }
@@ -274,13 +271,9 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         switch (!empty($details['CHECKOUTSTATUS']) ? $details['CHECKOUTSTATUS'] : null) {
             case 'PaymentActionCompleted':
             case 'PaymentCompleted':
-                $this->redirect(
-                    array(
-                        'controller' => 'checkout',
-                        'action' => 'finish',
-                        'sUniqueID' => $details['PAYMENTREQUEST_0_CUSTOM']
-                    )
-                );
+                $this->forward('finish', 'checkout', 'frontend', array(
+                    'sUniqueID' => $details['PAYMENTREQUEST_0_CUSTOM']
+                ));
                 break;
             case 'PaymentActionNotInitiated':
                 /**
@@ -316,19 +309,15 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
                         $redirectUrl .= '&token=' . urlencode($response['TOKEN']);
                         $this->redirect($redirectUrl);
                     } else {
-                        $this->redirect(
-                            array(
-                                'controller' => 'checkout',
-                                'action' => 'finish',
-                                'sUniqueID' => $response['PAYMENTREQUEST_0_CUSTOM']
-                            )
-                        );
+                        $this->forward('finish', 'checkout', 'frontend', array(
+                            'sUniqueID' => $response['PAYMENTREQUEST_0_CUSTOM']
+                        ));
                     }
                     /**
                      * If the user is logged in but using the express checkout, this condition will be run
                      */
                 } elseif ($this->isUserLoggedIn() && $this->getOrderNumber() === null) {
-                    $this->redirect(array('controller' => 'checkout'));
+                    $this->forward('index', 'checkout');
                     /**
                      * If the user is not logged in at all, he will be registered
                      */
@@ -336,7 +325,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
                     if (!empty($details['PAYERID']) && !empty($details['PAYMENTREQUEST_0_SHIPTONAME'])) {
                         $this->createAccount($details);
                     }
-                    $this->redirect(array('controller' => 'checkout'));
+                    $this->forward('index', 'checkout');
                 }
                 break;
             case 'PaymentActionInProgress':
@@ -551,7 +540,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
                     SELECT id, 1 FROM s_order WHERE ordernumber = ?
                     ON DUPLICATE KEY UPDATE swag_payal_express = 1
                 ';
-                $this->get('db')->query($sql, array($orderNumber, ));
+                $this->get('db')->query($sql, array($orderNumber,));
             } catch (Exception $e) {
             }
         }

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -79,7 +79,6 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         } elseif ($this->getPaymentShortName() == 'paypal') {
             $this->forward('gateway');
         } else {
-            $this->redirect(array('controller' => 'checkout'));
             $this->forward('index', 'checkout');
         }
     }


### PR DESCRIPTION
I experienced, as described by another person in [this thread on forum.shopware.com](http://forum.shopware.com/discussion/33377/interner-server-fehler-500-bei-paypal-zahlungsabschluss) and issue [SW-13531](https://issues.shopware.com/#/issues/SW-13531), the problem, that after the successful payment, the user gets redirected back to the PaymentPaypal-Controller and receives an error 500.

I wasn't able to pinpoint the exact location where this error was created, however, it must have something to do with Line [319](https://github.com/shopwareLabs/SwagPaymentPaypal/blob/f73bd24e1fc63b90d8d38c118bb92f7bcbe0c97f/Controllers/Frontend/PaymentPaypal.php#L319) of the PaymentPaypal-Controller, because any log-statement before this line were executed, but none within the redirect-function of Enlight_Controller_Action.

By switching out the redirect-calls with equivalent calls of the forward-function, I was able to eliminate the error, which is why I opened this pull request.
