### PR TITLE
Use cacert.pem (Bundle of CA Root Certificates) from shopware core when

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -950,7 +950,15 @@ EOD;
     public function onInitResourcePaypalRestClient()
     {
         require_once __DIR__ . '/Components/Paypal/RestClient.php';
-        $client = new Shopware_Components_Paypal_RestClient($this->Config());
+
+
+        $rootDir = Shopware()->Container()->getParameter('kernel.root_dir');
+        $caPath = $rootDir.'/engine/Shopware/Components/HttpClient/cacert.pem';
+        if (!is_readable($caPath)) {
+            $caPath = null;
+        }
+
+        $client = new Shopware_Components_Paypal_RestClient($this->Config(), $caPath);
 
         return $client;
     }

--- a/Components/Paypal/RestClient.php
+++ b/Components/Paypal/RestClient.php
@@ -33,20 +33,23 @@ class Shopware_Components_Paypal_RestClient extends Zend_Http_Client
      * Expects a configuration parameter.
      *
      * @param Enlight_Config $config
+     * @param string $caPath path to Bundle of CA Root Certificates (see: https://curl.haxx.se/ca/cacert.pem)
+     * @throws Zend_Http_Client_Exception
      */
-    public function __construct($config)
+    public function __construct($config, $caPath = null)
     {
         $this->pluginConfig = $config;
         parent::__construct($this->getBaseUri());
-        $this->setAdapter(self::createAdapterFromConfig($config));
+        $this->setAdapter(self::createAdapterFromConfig($config, $caPath));
     }
 
     /**
      * @param Enlight_Config $config
+     * @param string $caPath path to Bundle of CA Root Certificates (see: https://curl.haxx.se/ca/cacert.pem)
      * @see https://github.com/paypal/sdk-core-php
      * @return Zend_Http_Client_Adapter_Curl|Zend_Http_Client_Adapter_Socket
      */
-    public static function createAdapterFromConfig($config)
+    public static function createAdapterFromConfig($config, $caPath = null)
     {
         $curl = $config->get('paypalCurl', true);
         $timeout = $config->get('paypalTimeout') ?: 60;
@@ -62,6 +65,11 @@ class Shopware_Components_Paypal_RestClient extends Zend_Http_Client
                 $adapter->setCurlOption(CURLOPT_SSL_VERIFYPEER, false);
                 $adapter->setCurlOption(CURLOPT_SSL_VERIFYHOST, false);
             }
+
+            if ($caPath) {
+                $adapter->setCurlOption(CURLOPT_CAINFO, $caPath);
+            }
+
             $adapter->setCurlOption(CURLOPT_TIMEOUT, $timeout);
             //$adapter->setCurlOption(CURLOPT_SSL_CIPHER_LIST, 'TLSv1');
             //$adapter->setCurlOption(CURLOPT_SSL_VERIFYPEER, 1);


### PR DESCRIPTION
Use cacert.pem (Bundle of CA Root Certificates) from shopware core when available.

Please note that this code in entirely untested.
