### PR TITLE
Improve update support starting the update with versions at or below 3.1.0

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -343,10 +343,10 @@ EOD;
         $oldMenuEntry = $this->Menu()->findOneBy(array('controller' => 'PaymentPaypal', 'action' => 'Index'));
         if ( $oldMenuEntry ) {
             $oldMenuEntry->setClass('paypal--icon');
-	        $oldMenuEntry->setLabel('PayPal');
-	        $oldMenuEntry->setActive(1);
-	        $oldMenuEntry->setParent($parent);
-            $this->Application()->Models()->flush($oldMenuEntry);
+            $oldMenuEntry->setLabel('PayPal');
+            $oldMenuEntry->setActive(1);
+            $oldMenuEntry->setParent($parent);
+            $this->get('models')->flush($oldMenuEntry);
         } else {
             $this->createMenuItem(
                 array(

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -178,7 +178,7 @@ EOD;
         $logo = 'paypal_logo.png';
         $mediaPath = $this->Application()->DocPath() . 'media/image/' . $logo;
 
-	    /** @var \Shopware\Models\Media\Repository $mediaRepo */
+        /** @var \Shopware\Models\Media\Repository $mediaRepo */
         $mediaRepo = $this->get('models')->getRepository('Shopware\Models\Media\Media');
         $image = $mediaRepo->findOneBy(array('name' => 'paypal_logo'));
         if ($image) {
@@ -339,7 +339,7 @@ EOD;
     {
         /** @var \Shopware\Models\Menu\Menu $parent */
         $parent = $this->Menu()->findOneBy(array('label' => 'Zahlungen'));
-	    /** @var \Shopware\Models\Menu\Menu $oldMenuEntry */
+        /** @var \Shopware\Models\Menu\Menu $oldMenuEntry */
         $oldMenuEntry = $this->Menu()->findOneBy(array('controller' => 'PaymentPaypal', 'action' => 'Index'));
         if ( $oldMenuEntry ) {
             $oldMenuEntry->setClass('paypal--icon');

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -178,7 +178,7 @@ EOD;
         $logo = 'paypal_logo.png';
         $mediaPath = $this->Application()->DocPath() . 'media/image/' . $logo;
 
-	    /** @var Shopware\Models\Media\Repository $mediaRepo */
+	    /** @var \Shopware\Models\Media\Repository $mediaRepo */
         $mediaRepo = $this->get('models')->getRepository('Shopware\Models\Media\Media');
         $image = $mediaRepo->findOneBy(array('name' => 'paypal_logo'));
         if ($image) {

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -337,17 +337,28 @@ EOD;
      */
     private function createMyMenu()
     {
+        /** @var \Shopware\Models\Menu\Menu $parent */
         $parent = $this->Menu()->findOneBy(array('label' => 'Zahlungen'));
-        $this->createMenuItem(
-            array(
-                'label' => 'PayPal',
-                'controller' => 'PaymentPaypal',
-                'action' => 'Index',
-                'class' => 'paypal--icon',
-                'active' => 1,
-                'parent' => $parent
-            )
-        );
+	    /** @var \Shopware\Models\Menu\Menu $oldMenuEntry */
+        $oldMenuEntry = $this->Menu()->findOneBy(array('controller' => 'PaymentPaypal', 'action' => 'Index'));
+        if ( $oldMenuEntry ) {
+            $oldMenuEntry->setClass('paypal--icon');
+	        $oldMenuEntry->setLabel('PayPal');
+	        $oldMenuEntry->setActive(1);
+	        $oldMenuEntry->setParent($parent);
+            $this->Application()->Models()->flush($oldMenuEntry);
+        } else {
+            $this->createMenuItem(
+                array(
+                    'label' => 'PayPal',
+                    'controller' => 'PaymentPaypal',
+                    'action' => 'Index',
+                    'class' => 'paypal--icon',
+                    'active' => 1,
+                    'parent' => $parent
+                )
+            );
+        }
     }
 
     /**

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -31,7 +31,7 @@ class Shopware_Plugins_Frontend_SwagPaymentPaypal_Bootstrap extends Shopware_Com
     }
 
     /**
-     * @return bool
+     * @return array|bool
      */
     public function uninstall()
     {
@@ -178,6 +178,7 @@ EOD;
         $logo = 'paypal_logo.png';
         $mediaPath = $this->Application()->DocPath() . 'media/image/' . $logo;
 
+	    /** @var Shopware\Models\Media\Repository $mediaRepo */
         $mediaRepo = $this->get('models')->getRepository('Shopware\Models\Media\Media');
         $image = $mediaRepo->findOneBy(array('name' => 'paypal_logo'));
         if ($image) {
@@ -207,7 +208,7 @@ EOD;
      * Activate the plugin paypal plugin.
      * Sets the active flag in the payment row.
      *
-     * @return bool
+     * @return array|bool
      */
     public function enable()
     {
@@ -226,7 +227,7 @@ EOD;
     /**
      * Disable plugin method and sets the active flag in the payment row
      *
-     * @return bool
+     * @return array|bool
      */
     public function disable()
     {


### PR DESCRIPTION
While updating one clients shop and leading an unsatisfactory discussion with the Shopware support team i've decided to share my solution for this minimal problem thus making the "we will not support this fixed plugin" statement moot.

Basically you only missed checking whether the menu item has already been created previously so any version equal to or below 3.1.0 tries to create an already existing menu item (causing the update to crash at this line of code beacuse of database restrictions). When fixed with this pull request, the menu item is loaded from the database and is only modified and saved.

I've modified the createMyMenu function to take this into account and only modify the record instead of creating a new one. This modification has been tested on my side using a cleanly installed 4.2.3 Shop, installing the Paypal Plugin Version 2.1.7 (which has been active on my clients shop), running the update to 5.1.6 and updating the plugin afterwards.

Also included are minor type hints for PhpStorm to not have hiccups on return types.