### PR TITLE
Fix AddressValidator

### DIFF
--- a/Components/Paypal/AddressValidator.php
+++ b/Components/Paypal/AddressValidator.php
@@ -34,7 +34,7 @@ class AddressValidator implements AddressValidatorInterface
      */
     public function validate(Address $address)
     {
-        if (!$this->container->get('front')->Request()
+        if (!$this->container->get('front')->Request() || !$this->container->get('front')->Request()
             || $this->container->get('front')->Request()->getControllerName() !== 'payment_paypal'
         ) {
             $this->innerValidator->validate($address);


### PR DESCRIPTION
Fix an issue causing the `PHP Fatal error:  Uncaught Error: Call to a member function getControllerName() on null in engine/Shopware/Plugins/Community/Frontend/SwagPaymentPaypal/Components/Paypal/AddressValidator.php:38PHP Fatal error:  Uncaught Error: Call to a member function getControllerName() on null in engine/Shopware/Plugins/Community/Frontend/SwagPaymentPaypal/Components/Paypal/AddressValidator.php:38`.

We ran into this problem when using the API components on CLI for a customer import.