### PR TITLE
Fix error while creating new user via PHP-API  CLI

### DIFF
--- a/Components/Paypal/AddressValidator.php
+++ b/Components/Paypal/AddressValidator.php
@@ -35,6 +35,7 @@ class AddressValidator implements AddressValidatorInterface
     public function validate(Address $address)
     {
         if (!$this->container->get('front')->Request()
+            || $this->container->get('front')->Request() === null
             || $this->container->get('front')->Request()->getControllerName() !== 'payment_paypal'
         ) {
             $this->innerValidator->validate($address);


### PR DESCRIPTION
While creating a new user via PHP-API validation does not work, because in CLI-Mode Request is null.
In this case we also have to call parent validator so i added this line.

// Shopware\Components\Api\Manager
$userManager = Manager::getResource('customer');
$userManager->create($userData)

Cheers,
Rafael Kutscha