### PR TITLE
Update ajax_cart.tpl

### DIFF
--- a/Views/responsive/frontend/checkout/ajax_cart.tpl
+++ b/Views/responsive/frontend/checkout/ajax_cart.tpl
@@ -1,6 +1,7 @@
 {extends file="parent:frontend/checkout/ajax_cart.tpl"}
 
-{block name="frontend_checkout_ajax_cart_button_container_inner" append}
+{block name="frontend_checkout_ajax_cart_button_container_inner"}
+    {$smarty.block.parent}
     {if $sBasket.content}
         {include file="frontend/_includes_paypal/express.tpl"}
     {/if}


### PR DESCRIPTION
Due to a known smarty bug when overwriting / appending templates multiple times, we shouldnt use append / prepend and rather include the parent with {$smarty.block.parent}.
If a theme template already overwrites the frontend_checkout_ajax_cart_button_container_inner block, the paypal plugin multiplies the buttons in the ajax cart.
Correct template overwrite in custom theme: http://imgur.com/a/DJeVU
Paypal plugin without this commit: http://imgur.com/a/h5pvT
After this commit: http://imgur.com/a/wPERX