### PR TITLE
Fix-Issues-With-Missing-Addional-Address-Line

### DIFF
--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -643,7 +643,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         if (version_compare(Shopware::VERSION, '4.4.0', '>=') || Shopware::VERSION === '___VERSION___') {
             $data['billing']['street'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET'];
             if (!empty($details['PAYMENTREQUEST_0_SHIPTOSTREET2'])) {
-                $data['billing']['additional_address_line1'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET2'];
+                $data['billing']['additionalAddressLine1'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET2'];
             }
         } else {
             $street = explode(' ', $details['PAYMENTREQUEST_0_SHIPTOSTREET']);

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -885,23 +885,23 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         if (!empty($shipping['streetnumber'])) {
             $shipping['street'] .= ' ' . $shipping['streetnumber'];
         }
-		if (version_compare(Shopware::VERSION, '4.4.0', '>=') && version_compare(Shopware::VERSION, '5.2.0', '<')) {
+	if (version_compare(Shopware::VERSION, '4.4.0', '>=') && version_compare(Shopware::VERSION, '5.2.0', '<')) {
 
-	        if (!empty($shipping['additional_address_line1'])) {
-	            $shipping['street2'] = $shipping['additional_address_line1'];
-	            if (!empty($shipping['additional_address_line2'])) {
-	                $shipping['street2'] .= ' ' . $shipping['additional_address_line2'];
-	            }
-	        }
+		if (!empty($shipping['additional_address_line1'])) {
+		    $shipping['street2'] = $shipping['additional_address_line1'];
+		    if (!empty($shipping['additional_address_line2'])) {
+			$shipping['street2'] .= ' ' . $shipping['additional_address_line2'];
+		    }
+		}
 
-	    } elseif (version_compare(Shopware::VERSION, '5.2.0', '>=') || Shopware::VERSION === '___VERSION___') {
+    	} elseif (version_compare(Shopware::VERSION, '5.2.0', '>=') || Shopware::VERSION === '___VERSION___') {
 
-	    	if (!empty($shipping['additionalAddressLine1'])) {
-	            $shipping['street2'] = $shipping['additionalAddressLine1'];
-	            if (!empty($shipping['additionalAddressLine2'])) {
-	                $shipping['street2'] .= ' ' . $shipping['additionalAddressLine2'];
-	            }
-	        }
+		if (!empty($shipping['additionalAddressLine1'])) {
+		    $shipping['street2'] = $shipping['additionalAddressLine1'];
+		    if (!empty($shipping['additionalAddressLine2'])) {
+			$shipping['street2'] .= ' ' . $shipping['additionalAddressLine2'];
+		    }
+		}
 
         } else {
             $shipping['street2'] = '';

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -885,11 +885,24 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         if (!empty($shipping['streetnumber'])) {
             $shipping['street'] .= ' ' . $shipping['streetnumber'];
         }
-        if (!empty($shipping['additional_address_line1'])) {
-            $shipping['street2'] = $shipping['additional_address_line1'];
-            if (!empty($shipping['additional_address_line2'])) {
-                $shipping['street2'] .= ' ' . $shipping['additional_address_line2'];
-            }
+		if (version_compare(Shopware::VERSION, '4.4.0', '>=') && version_compare(Shopware::VERSION, '5.2.0', '<')) {
+
+	        if (!empty($shipping['additional_address_line1'])) {
+	            $shipping['street2'] = $shipping['additional_address_line1'];
+	            if (!empty($shipping['additional_address_line2'])) {
+	                $shipping['street2'] .= ' ' . $shipping['additional_address_line2'];
+	            }
+	        }
+
+	    } elseif (version_compare(Shopware::VERSION, '5.2.0', '>=') || Shopware::VERSION === '___VERSION___') {
+
+	    	if (!empty($shipping['additionalAddressLine1'])) {
+	            $shipping['street2'] = $shipping['additionalAddressLine1'];
+	            if (!empty($shipping['additionalAddressLine2'])) {
+	                $shipping['street2'] .= ' ' . $shipping['additionalAddressLine2'];
+	            }
+	        }
+
         } else {
             $shipping['street2'] = '';
         }

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -640,11 +640,18 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
         $data['billing']['firstname'] = $details['FIRSTNAME'];
         $data['billing']['lastname'] = $details['LASTNAME'];
 
-        if (version_compare(Shopware::VERSION, '4.4.0', '>=') || Shopware::VERSION === '___VERSION___') {
+         if (version_compare(Shopware::VERSION, '4.4.0', '>=') && version_compare(Shopware::VERSION, '5.2.0', '<')) {
+            $data['billing']['street'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET'];
+            if (!empty($details['PAYMENTREQUEST_0_SHIPTOSTREET2'])) {
+                $data['billing']['additional_address_line1'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET2'];
+            }
+
+        } elseif (version_compare(Shopware::VERSION, '5.2.0', '>=') || Shopware::VERSION === '___VERSION___') {
             $data['billing']['street'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET'];
             if (!empty($details['PAYMENTREQUEST_0_SHIPTOSTREET2'])) {
                 $data['billing']['additionalAddressLine1'] = $details['PAYMENTREQUEST_0_SHIPTOSTREET2'];
             }
+
         } else {
             $street = explode(' ', $details['PAYMENTREQUEST_0_SHIPTOSTREET']);
             $data['billing']['street'] = $street[0];


### PR DESCRIPTION
When using the addional adress-line in paypal the entry won't be saved, because of the wrong field-naming.