### PR TITLE
added possibility to the NOSHIPPING flag for PayPal express request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -919,6 +919,23 @@ EOD;
                 'vtype' => 'alphanum',
             )
         );
+
+        $noShippingSettings = array(
+            array(0, array('en_GB' => 'PayPal displays the shipping address on the PayPal pages', 'de_DE' => 'Die Versandadresse wird auf der PayPal Seite zur Auswahl angeboten')),
+            array(1, array('en_GB' => 'PayPal does not display shipping address fields and removes shipping information from the transaction.', 'de_DE' => 'PayPal zeigt keine Versandadressenauswahl an und entfenert jeglich Daten bezüglich der Versandadresse aus der Transaktion')),
+            array(2, array('en_GB' => 'If you do not pass the shipping address, PayPal obtains it from the buyer\'s account profile', 'de_DE' => 'Wird keine Versandadresse zu der PayPal seite übermittelt, wird die des Paypal Benutzerkontos benutzt.')),
+        );
+
+        $form->setElement(
+            'select',
+            'paypalNoShipping',
+            array(
+                'label' => 'Versandadressenauswahl',
+                'value' => 0,
+                'store' => $noShippingSettings,
+                'scope' => \Shopware\Models\Config\Element::SCOPE_SHOP,
+            )
+        );
     }
 
     private function createMyTranslations()

--- a/Controllers/Frontend/PaymentPaypal.php
+++ b/Controllers/Frontend/PaymentPaypal.php
@@ -141,6 +141,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
 
         $borderColor = ltrim($config->get('paypalCartBorderColor'), '#');
         $paymentAction = $config->get('paypalPaymentAction', 'Sale');
+        $noShipping = $config->get('paypalNoShipping', 0);
         $user = $this->getUser();
 
         $params = array(
@@ -159,6 +160,7 @@ class Shopware_Controllers_Frontend_PaymentPaypal extends Shopware_Controllers_F
             'GIROPAYCANCELURL' => $router->assemble(array('action' => 'cancel', 'forceSecure' => true)),
             'BANKTXNPENDINGURL' => $router->assemble(array('action' => 'return', 'forceSecure' => true)),
             'ALLOWNOTE' => 1,
+            'NOSHIPPING' => $noShipping,
             'ADDROVERRIDE' => $user === null ? 0 : 1,
             'BRANDNAME' => $shopName,
             'LOGOIMG' => $logoImage,


### PR DESCRIPTION
We had the problem that customers from all around the world were able to order products. To block that we need to introduce NOSHIPPING request parameter.